### PR TITLE
fix: gemspec file prevented usage on rails 6

### DIFF
--- a/devise-tailwindcssed.gemspec
+++ b/devise-tailwindcssed.gemspec
@@ -59,8 +59,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop-performance", "~> 1.1"
   spec.add_development_dependency "rubocop-rspec", "~> 1.30"
 
-  spec.add_dependency "rails", "~> 5.2.3", "<= 6.0"
-  spec.add_runtime_dependency "railties", "> 4.0", "< 6.0"
+  spec.add_dependency "rails", "~> 6.0.0", "<= 6.1"
+  spec.add_runtime_dependency "railties", "> 4.0", "< 6.1"
 
   spec.extra_rdoc_files = Dir["README*", "LICENSE*"]
   spec.require_paths = ["lib"]

--- a/devise-tailwindcssed.gemspec
+++ b/devise-tailwindcssed.gemspec
@@ -59,7 +59,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop-performance", "~> 1.1"
   spec.add_development_dependency "rubocop-rspec", "~> 1.30"
 
-  spec.add_dependency "rails", "~> 6.0.0", "<= 6.1"
+  spec.add_dependency "rails", ">= 5.2.3", "<= 6.1"
   spec.add_runtime_dependency "railties", "> 4.0", "< 6.1"
 
   spec.extra_rdoc_files = Dir["README*", "LICENSE*"]


### PR DESCRIPTION
When I used the gem I got this after running `bundle` using rails 6.
```
Bundler could not find compatible versions for gem "rails":
  In snapshot (Gemfile.lock):
    rails (= 6.0.0)

  In Gemfile:
    rails (~> 6.0.0)

    devise-tailwindcssed was resolved to 0.1.0, which depends on
      rails (~> 5.2.3, <= 6.0)
```
I have changed it to accept rails 6 and < 6.1