### PR TITLE
Fix typographical error in classname found in sessions/new

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -33,7 +33,7 @@
             <%= f.label :password, class: "block text-gray-700 text-sm font-bold mb-2" %>
             <%= f.password_field :password,
                                  autocomplete: "current-password",
-                                 class: "shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight foucs:outline-none focus:shadow-outline"
+                                 class: "shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
             %>
         </div>
 


### PR DESCRIPTION
While using for gem, I found a small typographical error in a `focus` pseudo class found in `sessions/new.html.erb`. 

Thank you for a great product. 