### PR TITLE
Removed max version of Ruby. Also enabled all new rubocop flags by de…

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,5 @@
 inherit_gem:
   caliber: config/all.yml
+
+AllCops:
+  NewCops: enable

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,6 +165,7 @@ GEM
     marcel (1.0.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
+    mini_portile2 (2.8.1)
     minitest (5.16.3)
     nenv (0.3.0)
     net-imap (0.3.2)
@@ -177,7 +178,8 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.8)
-    nokogiri (1.13.10-x86_64-darwin)
+    nokogiri (1.13.10)
+      mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     notiffany (0.1.3)
       nenv (~> 0.1)
@@ -291,6 +293,7 @@ GEM
     zeitwerk (2.6.6)
 
 PLATFORMS
+  arm64-darwin-22
   x86_64-darwin-22
 
 DEPENDENCIES

--- a/devise-tailwindcssed.gemspec
+++ b/devise-tailwindcssed.gemspec
@@ -44,10 +44,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r(^exe/)) { |f| File.basename(f) }
 
   # Resolve conflict between the gemspec's required_ruby_version and rubocop's TargetRubyVersion
-  # rubocop:disable  Gemspec/RequiredRubyVersion
-  spec.required_ruby_version = ">= 2.6", "< 3.2"
-  # rubocop:enable  Gemspec/RequiredRubyVersion
-
+  spec.required_ruby_version = ">= 2.6"
   spec.add_dependency "rails", ">= 5.2.3.4", "< 7.1"
   spec.add_runtime_dependency "railties", "> 4.0", "< 7.1"
 


### PR DESCRIPTION
…fault.

Was not able to run on Ruby 3.2 due to gemspec configuration. 

Opened it up by removing the max version. Don't know what the reason was for locking it down, but I can presume it was related to worries with the 3.2 updates.  


