### PR TITLE
Fix typo in installation commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ gem 'devise-tailwindcssed'
 
 And then execute:
 
-    $ bundle
+    bundle
 
 Or install it yourself as:
 
-    $ gem install devise-tailwindcssed
+    gem install devise-tailwindcssed
 
 ## Usage
 


### PR DESCRIPTION
### Fix typo in installation commands

 ## Checklist
- [x] I have read this repository's [contribution guidelines.](https://github.com/posiczko/devise-tailwindcssed/blob/de811e9bcf6b01c55de4f9b4b58e405a68a1f72b/CODE_OF_CONDUCT.md)
- [x] My pull request has a descriptive title (not a vague title like Update index.MD)
- [x] My pull request targets the master branch of this [project](https://github.com/posiczko/devise-tailwindcssed).
- [x] I added relevant documentation for all the files I changed

## Summary
I removed the `$` in the installation commands as it is not necessary when copying the command (the terminal already has it) and will throw an error if pasted in the terminal with it. I always have to remove it whenever I'm copying it here.

 ## What changes have been made?
- [x] Change `$ bundle` to `bundle`
- [x] Change `$ gem install devise-tailwindcssed` to `gem install devise-tailwindcssed`

## Author
- @didierganthier