### PR TITLE
Update devise-tailwindcssed.gemspec

### DIFF
--- a/devise-tailwindcssed.gemspec
+++ b/devise-tailwindcssed.gemspec
@@ -45,11 +45,11 @@ Gem::Specification.new do |spec|
 
   # Resolve conflict between the gemspec's required_ruby_version and rubocop's TargetRubyVersion
   # rubocop:disable  Gemspec/RequiredRubyVersion
-  spec.required_ruby_version = ">= 2.6", "< 3.2"
+  spec.required_ruby_version = ">= 2.6", "<= 3.2.2"
   # rubocop:enable  Gemspec/RequiredRubyVersion
 
-  spec.add_dependency "rails", ">= 5.2.3.4", "< 7.1"
-  spec.add_runtime_dependency "railties", "> 4.0", "< 7.1"
+  spec.add_dependency "rails", ">= 5.2.3.4", "<= 7.1.1"
+  spec.add_runtime_dependency "railties", "> 4.0", "<= 7.1.1"
 
   spec.extra_rdoc_files = Dir["README*", "LICENSE*"]
   spec.require_paths = ["lib"]


### PR DESCRIPTION
Installation was failing due to the requirements, but generation works with ruby 3.2.2 and rails 7.1.1